### PR TITLE
fix: apply filters to referenced elements

### DIFF
--- a/hash.ts
+++ b/hash.ts
@@ -863,6 +863,7 @@ export function hasher(
           const fromVals = fromAttrs.map(a => e.getAttribute(a));
           return fromVals.every((val, i) => toVals[i] === val) && toE;
         })
+        .filter(shouldHashElement)
         .map(hash)
         .sort();
       if (hashes.length) {


### PR DESCRIPTION
Fixes a bug where the `element` and `namespace` filters are only applied to direct DOM children of an element, never to referenced elements (e.g. to filter out an `LNodeType` referenced from an  `LN`)