### PR TITLE
Fix missing selection text in md select

### DIFF
--- a/oscd-diff.ts
+++ b/oscd-diff.ts
@@ -556,7 +556,7 @@ export default class OscdDiff extends LitElement {
                       value=${filterName}
                       ?selected=${this.selectedFilterName === filterName}
                     >
-                      ${filterName}</md-select-option
+                      <div slot="headline">${filterName}</div></md-select-option
                     >`,
                 )}
               </md-filled-select>
@@ -643,7 +643,7 @@ export default class OscdDiff extends LitElement {
             ${Object.keys(this.docs).map(
               name =>
                 html`<md-select-option value="${name}"
-                  >${name}</md-select-option
+                  ><div slot="headline">${name}</div></md-select-option
                 >`,
             )}
           </md-filled-select>
@@ -658,7 +658,7 @@ export default class OscdDiff extends LitElement {
             ${Object.keys(this.docs).map(
               name =>
                 html`<md-select-option value="${name}"
-                  >${name}</md-select-option
+                  ><div slot="headline">${name}</div></md-select-option
                 >`,
             )}
           </md-filled-select>

--- a/oscd-diff.ts
+++ b/oscd-diff.ts
@@ -953,6 +953,7 @@ export default class OscdDiff extends LitElement {
 
     :host md-filled-select {
       min-width: 260px;
+      width: 100%;
     }
 
     #filters-import-field {


### PR DESCRIPTION
Resolves #86

Also includes a small styling adjustment, to make the "Comparison Rules" selector, take up the available space within the row.
